### PR TITLE
Count number of good locations before showing Start button.

### DIFF
--- a/app/src/main/java/com/goldrushcomputing/androidlocationstarterkitinkotlin/MainActivity.kt
+++ b/app/src/main/java/com/goldrushcomputing/androidlocationstarterkitinkotlin/MainActivity.kt
@@ -61,6 +61,11 @@ class MainActivity : AppCompatActivity() {
     private var kalmanNGLocationMarkerBitmapDescriptor: BitmapDescriptor? = null
     private var malMarkers = ArrayList<Marker>()
 
+    /* Check enough good locations before showing START button */
+    private var enoughLocationsReceiver: BroadcastReceiver? = null
+    private var showStartButton = false
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -134,6 +139,13 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        enoughLocationsReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                // Make startButton visible
+                startButton?.visibility = View.VISIBLE
+            }
+        }
+
         locationUpdateReceiver?.let{
             @Suppress("DEPRECATION")
             LocalBroadcastManager.getInstance(this).registerReceiver(
@@ -150,8 +162,17 @@ class MainActivity : AppCompatActivity() {
             )
         }
 
+        enoughLocationsReceiver?.let{
+            @Suppress("DEPRECATION")
+            LocalBroadcastManager.getInstance(this).registerReceiver(
+                it,
+                IntentFilter("GotEnoughLocations")
+            )
+        }
+
         startButton = this.findViewById(R.id.start_button) as ImageButton
         stopButton = this.findViewById(R.id.stop_button) as ImageButton
+        startButton?.visibility = View.INVISIBLE
         stopButton?.visibility = View.INVISIBLE
 
 


### PR DESCRIPTION
This is a demo to show how we can count good locations before allowing user to track their locations.
Here is the step
## 1. 
Add a varibale `goodGpsCount` to count the number of initial good locations.
[goodGpsCount](https://github.com/mizutori/AndroidLocationStarterKitInKotlin/compare/secure-accuracy?expand=1#diff-73ccae8d1b2c89ef24ff25f60549f85125dc67d46c73e466ed9e0c19e2109129R66)

## 2. 
In onLocationUpdate, after filtering the new location, if it passes the filter, count up `goodGpsCount`. 
If `goodGpsCount` becomes more than or equal to 3, send broadcast to MainActivity.
https://github.com/mizutori/AndroidLocationStarterKitInKotlin/compare/secure-accuracy?expand=1#diff-73ccae8d1b2c89ef24ff25f60549f85125dc67d46c73e466ed9e0c19e2109129R66


## 3.
In MainActivity, make the `startButton` invisible in the beginning.
https://github.com/mizutori/AndroidLocationStarterKitInKotlin/compare/secure-accuracy?expand=1#diff-e4363ca693431b2287ffc5ce969d0abac1ee05f8729ff2d3a4efda2db4ca9df3R174

## 4. 
When receiving the broadcast of goodGpsCount, make `startButton` visible.
https://github.com/mizutori/AndroidLocationStarterKitInKotlin/compare/secure-accuracy?expand=1#diff-e4363ca693431b2287ffc5ce969d0abac1ee05f8729ff2d3a4efda2db4ca9df3R144
 
 
# Other Note
* I changed the function `filterAndAddLocation` to `filterLocation` to return null (if location doesn't pass the filter) or location (if the location passes the filter). This is because I want to use this function even before the user presses `startButton`. 
* I removed Kalman filter to demonstrate this idea with maximum simplicity.